### PR TITLE
[logos] Support multi-line block arguments in `%orig` calls

### DIFF
--- a/bin/lib/Logos/Generator/Base/Common.pm
+++ b/bin/lib/Logos/Generator/Base/Common.pm
@@ -1,0 +1,15 @@
+package Logos::Generator::Base::Common;
+use strict;
+
+sub new {
+    my $class = shift;
+    my $self = {};
+    bless($self, $class);
+    return $self;
+}
+
+sub deleteLine {
+	return "";
+}
+
+1;

--- a/bin/lib/Logos/Generator/Base/Function.pm
+++ b/bin/lib/Logos/Generator/Base/Function.pm
@@ -2,6 +2,8 @@ package Logos::Generator::Base::Function;
 use strict;
 use Logos::Generator;
 use Logos::Util;
+use parent qw(Logos::Generator::Base::Common);
+
 
 sub _initExpression {
 	my $self = shift;
@@ -193,5 +195,6 @@ sub notSoSmartSplit {
 
 	return $args;
 }
+
 
 1;

--- a/bin/lib/Logos/Generator/Base/Method.pm
+++ b/bin/lib/Logos/Generator/Base/Method.pm
@@ -1,6 +1,7 @@
 package Logos::Generator::Base::Method;
 use strict;
 use Logos::Util;
+use parent qw(Logos::Generator::Base::Common);
 
 sub _symbolName {
 	my $self = shift;

--- a/bin/lib/Logos/Generator/MobileSubstrate/Generator.pm
+++ b/bin/lib/Logos/Generator/MobileSubstrate/Generator.pm
@@ -19,4 +19,12 @@ sub preamble {
 	}
 }
 
+sub staticDeclarations {
+	my $self = shift;
+	return join("\n", ($self->SUPER::staticDeclarations(),
+		"asm(\".linker_option \\\"-framework\\\", \\\"CydiaSubstrate\\\"\");",
+		"" # extra line break for readability
+	));
+}
+
 1;

--- a/bin/lib/Logos/Generator/MobileSubstrate/Generator.pm
+++ b/bin/lib/Logos/Generator/MobileSubstrate/Generator.pm
@@ -22,7 +22,7 @@ sub preamble {
 sub staticDeclarations {
 	my $self = shift;
 	return join("\n", ($self->SUPER::staticDeclarations(),
-		"asm(\".linker_option \\\"-framework\\\", \\\"CydiaSubstrate\\\"\");",
+		"__asm__(\".linker_option \\\"-framework\\\", \\\"CydiaSubstrate\\\"\");",
 		"" # extra line break for readability
 	));
 }

--- a/bin/lib/Logos/Generator/libhooker/Generator.pm
+++ b/bin/lib/Logos/Generator/libhooker/Generator.pm
@@ -15,8 +15,20 @@ sub preamble {
 	if ($skipIncludes) {
 		return $self->SUPER::preamble();
 	} else {
-		return join("\n", ($self->SUPER::preamble(), "#import <libhooker/libblackjack.h>\n#import <objc/runtime.h>"));
+		return join("\n", ($self->SUPER::preamble(),
+			"#import <libhooker/libblackjack.h>",
+			"#import <objc/runtime.h>"
+		));
 	}
+}
+
+sub staticDeclarations {
+	my $self = shift;
+	return join("\n", ($self->SUPER::staticDeclarations(),
+		"asm(\".linker_option \\\"-lhooker\\\"\");",
+		"asm(\".linker_option \\\"-lblackjack\\\"\");",
+		"" # extra line break for readability
+	));
 }
 
 1;

--- a/bin/lib/Logos/Generator/libhooker/Generator.pm
+++ b/bin/lib/Logos/Generator/libhooker/Generator.pm
@@ -25,8 +25,8 @@ sub preamble {
 sub staticDeclarations {
 	my $self = shift;
 	return join("\n", ($self->SUPER::staticDeclarations(),
-		"asm(\".linker_option \\\"-lhooker\\\"\");",
-		"asm(\".linker_option \\\"-lblackjack\\\"\");",
+		"__asm__(\".linker_option \\\"-lhooker\\\"\");",
+		"__asm__(\".linker_option \\\"-lblackjack\\\"\");",
 		"" # extra line break for readability
 	));
 }

--- a/bin/logos.pl
+++ b/bin/logos.pl
@@ -458,9 +458,9 @@ foreach my $line (@lines) {
 				} else {
 					fileError($lineno, "Invalid argument structure in %orig");
 				}
-				
-				if ($orig_args =~ /%orig\b/) {
-					fileError($lineno, "%orig cannot be referenced in %orig arguments");
+
+				if ($orig_args =~ /%orig\b/ || $orig_args =~ /%log\b/) {
+					fileError($lineno, "Logos cannot be used within arguments to %orig");
 				}
 			}
 

--- a/bin/logos.pl
+++ b/bin/logos.pl
@@ -458,6 +458,10 @@ foreach my $line (@lines) {
 				} else {
 					fileError($lineno, "Invalid argument structure in %orig");
 				}
+				
+				if ($orig_args =~ /%orig\b/) {
+					fileError($lineno, "%orig cannot be referenced in %orig arguments");
+				}
 			}
 
 			if (!defined $currentClass) {

--- a/bin/logos.pl
+++ b/bin/logos.pl
@@ -429,22 +429,43 @@ foreach my $line (@lines) {
 			addPatch($patch);
 		} elsif($line =~ /\G%orig\b/gc) {
 			# %orig, with optional following parens.
+
+			my $patchStart = $-[0];
+			my $remaining = substr($line, pos($line));
+			my $orig_args = undef;
+			my $full_code = $remaining;
+			my $paren_depth = ($full_code =~ tr/(//) - ($full_code =~ tr/)//);
+			my $brace_depth = ($full_code =~ tr/{//) - ($full_code =~ tr/}//);
+			my $line_index = $lineno;
+			my $has_semicolon = 1;
+			
+			if($line =~ /\G\s*\(/gc) {
+				while ($paren_depth > 0 || $brace_depth > 0) {
+					$line_index++;
+					last unless defined $lines[$line_index];
+					$full_code .= "\n" . $lines[$line_index];
+					$paren_depth += ($lines[$line_index] =~ tr/(//) - ($lines[$line_index] =~ tr/)//);
+					$brace_depth += ($lines[$line_index] =~ tr/{//) - ($lines[$line_index] =~ tr/}//);
+				}
+
+				$has_semicolon = $full_code =~ /;\s*$/;
+				if ($has_semicolon) {
+					$full_code =~ s/;\s*$//;
+				}
+
+				if ($full_code =~ /^\s*\((.*)\)\s*$/s) {
+					$orig_args = $1;
+				} else {
+					fileError($lineno, "Invalid argument structure in %orig");
+				}
+			}
+
 			if (!defined $currentClass) {
 				fileError($lineno, "%orig does not make sense outside a function") if(!defined($currentFunction));
-				my $patchStart = $-[0];
-
-				my $remaining = substr($line, pos($line));
-				my $orig_args = undef;
-
-				my ($popen, $pclose) = matchedParenthesisSet($remaining);
-				if(defined $popen) {
-					$orig_args = substr($remaining, $popen, $pclose-$popen-1);;
-					pos($line) = pos($line) + $pclose;
-				}
 
 				my $patch = Patch->new();
 				$patch->line($lineno);
-				$patch->range($patchStart, pos($line));
+				$patch->range($patchStart, length($line));
 				if(!defined $orig_args or length($orig_args) < 1) {
 					if(grep {$_ eq "..."} @{$currentFunction->args}) {
 						fileError($lineno, "%orig requires arguments when hooking variadic functions");
@@ -452,30 +473,39 @@ foreach my $line (@lines) {
 				}
 				$patch->source(Patch::Source::Generator->new($currentFunction, 'originalFunctionCall', $orig_args));
 				addPatch($patch);
+
+				for (my $i = 1; $i <= $line_index - $lineno; $i++) {
+					my $patch = Patch->new();
+					$patch->line($lineno + $i);
+					$patch->range(0, length($lines[$lineno + $i]));
+					$patch->source(Patch::Source::Generator->new($currentFunction, 'deleteLine'));
+					addPatch($patch);
+				}
 			} else {
 				nestingMustContain($lineno, "%orig", \@nestingstack, "hook", "subclass");
 				fileError($lineno, "%orig does not make sense outside a method") if(!defined($currentMethod));
 				fileError($lineno, "%orig does not make sense outside a block") if($directiveDepth < 1);
 				fileWarning($lineno, "%orig in new method ".prettyPrintMethod($currentMethod)." will be non-operative.") if $currentMethod->isNew;
 
-				my $patchStart = $-[0];
-
-				my $remaining = substr($line, pos($line));
-				my $orig_args = undef;
-
-				my ($popen, $pclose) = matchedParenthesisSet($remaining);
-				if(defined $popen) {
-					$orig_args = substr($remaining, $popen, $pclose-$popen-1);;
-					pos($line) = pos($line) + $pclose;
-				}
-
 				my $capturedMethod = $currentMethod;
 				my $patch = Patch->new();
 				$patch->line($lineno);
-				$patch->range($patchStart, pos($line));
+				$patch->range($patchStart, length($line));
 				$patch->source(Patch::Source::Generator->new($capturedMethod, 'originalCall', $orig_args));
 				addPatch($patch);
+
+				for (my $i = 1; $i <= $line_index - $lineno; $i++) {
+					my $patch = Patch->new();
+					$patch->line($lineno + $i);
+					$patch->range(0, length($lines[$lineno + $i]));
+					$patch->source(Patch::Source::Generator->new($capturedMethod, 'deleteLine'));
+					addPatch($patch);
+				}
 			}
+
+			$line .= ";" if $has_semicolon;
+			pos($line) = length($line);
+
 		} elsif($line =~ /\G&\s*%orig\b/gc) {
 			# &%orig, at a word boundary
 			if (!defined $currentClass) {


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR adds the ability to specify inline blocks spanning multiple lines as arguments when calling `%orig(...)`, which was previously not supported.

Example `%orig(...)` usages that are now supported:

```
%orig(^{
    NSLog(@"foo");
});
```

```
%orig(arg1, arg2, ^(NSString *blockArg1) {
    NSLog(@"block arg: %@", blockArg1);
});
```

```
- (void)methodWithComplexBlock:(void (^)(NSString *, NSError *))completion {
    %orig(^(NSString *result, NSError *error) {
        if (error) {
            NSLog(@"Error: %@", error);
        }
        completion(result, error);
    });
}
```

Does this close any currently open issues?
------------------------------------------
This PR closes an issue that's been open for 10y: [\[#6\] "Logos errors out on calling %orig with an inline block with multiple lines."](https://github.com/theos/logos/issues/6)

Any relevant logs, error output, etc?
-------------------------------------
N/A

Any other comments?
-------------------
* This maintains backwards compatibility with existing Logos syntax. Developers do not need to modify their projects/code to accommodate this change.
* Using logos directives (`%orig`, `%log`, etc.) inside of a block passed to `%orig(...)` is currently **not supported**.
    * Attempting to do so will result in the following error: **Tweak.x:4: error: Logos cannot be used within arguments to %orig**.

Example of unsupported usage:

```
%orig(arg1, arg2, ^(NSString *blockArg1) {
    %orig(arg1, arg2, nil);
});

Tweak.x:4: error: Logos cannot be used within arguments to %orig
```

    
Where has this been tested?
---------------------------
**Operating System:** macOS Sonoma, iOS 14, iOS 18, Ubuntu 22.0.4

**Platform:** arm64, x86_64

**Target Platform:** iOS, iOS Simulator

**Toolchain Version:** Xcode 15.4

**SDK Version:** iOS 14, iOS 15, iOS 16.5

Unit Testing
------------

AFAIK, Logos (and Theos) lack official unit testing. This PR changes core behavior of the parser and has the potential to introduce significant breakage; this requires thorough testing to ensure reliability and backwards compatibility. To address this concern, I created a separate branch containing unit tests for my changes as well as some unrelated core behavior, as the project lacks these otherwise.

Coverage of these tests include, but is not limited to:

1. Basic `%orig` functionality to ensure backwards compatibility.
2. New multi-line block parsing capabilities.
3. Error handling for invalid syntax.
4. Edge cases such as complex argument structures nested `%orig` usage.

These tests validate the correctness of the current implementation and provide a safety net for future changes (helping prevent regressions). All of the tests I created can be found [here](https://github.com/EthanArbuckle/logos/tree/unit-tests/tests). 

[Direct link to the tests for `%orig` behavior](https://github.com/EthanArbuckle/logos/blob/unit-tests/tests/test_orig_directive.py).

I have Github Actions setup to run these tests (in my fork) -- they're currently passing: [Latest Github Action run](https://github.com/EthanArbuckle/logos/actions/runs/10354353990/job/28659432852). 